### PR TITLE
Unionize 2

### DIFF
--- a/methods.d.ts
+++ b/methods.d.ts
@@ -29,6 +29,7 @@ import {
   WebhookInfo,
 } from "./types";
 
+import Edited = Update.Edited;
 /** Extracts the parameters of a given method name */
 type Params<M extends keyof Telegram> = Parameters<Telegram[M]>;
 /** Extracts the return type of a given method name */
@@ -111,7 +112,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.TextMessage;
 
   /** Use this method to forward messages of any kind. On success, the sent Message is returned. */
   forwardMessage(args: {
@@ -145,7 +146,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.PhotoMessage;
 
   /** Use this method to send audio files, if you want Telegram clients to display them in the music player. Your audio must be in the .MP3 or .M4A format. On success, the sent Message is returned. Bots can currently send audio files of up to 50 MB in size, this limit may be changed in the future.
 
@@ -177,7 +178,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.AudioMessage;
 
   /** Use this method to send general files. On success, the sent Message is returned. Bots can currently send files of any type of up to 50 MB in size, this limit may be changed in the future. */
   sendDocument(args: {
@@ -201,7 +202,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.DocumentMessage;
 
   /** Use this method to send video files, Telegram clients support mp4 videos (other formats may be sent as Document). On success, the sent Message is returned. Bots can currently send video files of up to 50 MB in size, this limit may be changed in the future. */
   sendVideo(args: {
@@ -233,7 +234,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.VideoMessage;
 
   /** Use this method to send animation files (GIF or H.264/MPEG-4 AVC video without sound). On success, the sent Message is returned. Bots can currently send animation files of up to 50 MB in size, this limit may be changed in the future. */
   sendAnimation(args: {
@@ -263,7 +264,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.AnimationMessage;
 
   /** Use this method to send audio files, if you want Telegram clients to display the file as a playable voice message. For this to work, your audio must be in an .OGG file encoded with OPUS (other formats may be sent as Audio or Document). On success, the sent Message is returned. Bots can currently send voice messages of up to 50 MB in size, this limit may be changed in the future. */
   sendVoice(args: {
@@ -287,7 +288,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.VoiceMessage;
 
   /** Use this method to send video messages. On success, the sent Message is returned.
   As of v.4.0, Telegram clients support rounded square mp4 videos of up to 1 minute long. */
@@ -312,7 +313,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.VideoNoteMessage;
 
   /** Use this method to send a group of photos or videos as an album. On success, an array of the sent Messages is returned. */
   sendMediaGroup(args: {
@@ -324,7 +325,7 @@ export interface Telegram {
     disable_notification?: Boolean;
     /** If the messages are a reply, ID of the original message */
     reply_to_message_id?: Integer;
-  }): Message;
+  }): Array<Message.PhotoMessage | Message.VideoMessage>;
 
   /** Use this method to send point on the map. On success, the sent Message is returned. */
   sendLocation(args: {
@@ -346,7 +347,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.LocationMessage;
 
   /** Use this method to edit live location messages. A location can be edited until its live_period expires or editing is explicitly disabled by a call to stopMessageLiveLocation. On success, if the edited message was sent by the bot, the edited Message is returned, otherwise True is returned. */
   editMessageLiveLocation(args: {
@@ -362,7 +363,7 @@ export interface Telegram {
     longitude: Float;
     /** A JSON-serialized object for a new inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message | True;
+  }): (Edited & Message.LocationMessage) | True;
 
   /** Use this method to stop updating a live location message before live_period expires. On success, if the message was sent by the bot, the sent Message is returned, otherwise True is returned. */
   stopMessageLiveLocation(args: {
@@ -374,7 +375,7 @@ export interface Telegram {
     inline_message_id?: String;
     /** A JSON-serialized object for a new inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message | True;
+  }): (Edited & Message.LocationMessage) | True;
 
   /** Use this method to send information about a venue. On success, the sent Message is returned. */
   sendVenue(args: {
@@ -402,7 +403,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.VenueMessage;
 
   /** Use this method to send phone contacts. On success, the sent Message is returned. */
   sendContact(args: {
@@ -426,7 +427,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.ContactMessage;
 
   /** Use this method to send a native poll. On success, the sent Message is returned. */
   sendPoll(args: {
@@ -464,7 +465,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.PollMessage;
 
   /** Use this method to send an animated emoji that will display a random value. On success, the sent Message is returned. */
   sendDice(args: {
@@ -482,7 +483,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.DiceMessage;
 
   /** Use this method when you need to tell the user that something is happening on the bot's side. The status is set for 5 seconds or less (when a message arrives from your bot, Telegram clients clear its typing status). Returns True on success.
 
@@ -736,7 +737,7 @@ export interface Telegram {
     disable_web_page_preview?: Boolean;
     /** A JSON-serialized object for an inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message | True;
+  }): (Edited & Message.TextMessage) | True;
 
   /** Use this method to edit captions of messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned. */
   editMessageCaption(args: {
@@ -752,7 +753,7 @@ export interface Telegram {
     parse_mode?: ParseMode;
     /** A JSON-serialized object for an inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message | True;
+  }): (Edited & Message.CaptionableMessage) | True;
 
   /** Use this method to edit animation, audio, document, photo, or video messages. If a message is a part of a message album, then it can be edited only to a photo or a video. Otherwise, message type can be changed arbitrarily. When inline message is edited, new file can't be uploaded. Use previously uploaded file via its file_id or specify a URL. On success, if the edited message was sent by the bot, the edited Message is returned, otherwise True is returned. */
   editMessageMedia(args: {
@@ -766,7 +767,13 @@ export interface Telegram {
     media: InputMedia;
     /** A JSON-serialized object for a new inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message | True;
+  }):
+    | (Edited & Message.AnimationMessage)
+    | (Edited & Message.AudioMessage)
+    | (Edited & Message.DocumentMessage)
+    | (Edited & Message.PhotoMessage)
+    | (Edited & Message.VideoMessage)
+    | True;
 
   /** Use this method to edit only the reply markup of messages. On success, if edited message is sent by the bot, the edited Message is returned, otherwise True is returned. */
   editMessageReplyMarkup(args: {
@@ -778,7 +785,7 @@ export interface Telegram {
     inline_message_id: String;
     /** A JSON-serialized object for an inline keyboard. */
     reply_markup: InlineKeyboardMarkup;
-  }): Message | True;
+  }): (Edited & Message) | True;
 
   /** Use this method to stop a poll which was sent by the bot. On success, the stopped Poll with the final results is returned. */
   stopPoll(args: {
@@ -822,7 +829,7 @@ export interface Telegram {
       | ReplyKeyboardMarkup
       | ReplyKeyboardRemove
       | ForceReply;
-  }): Message;
+  }): Message.StickerMessage;
 
   /** Use this method to get a sticker set. On success, a StickerSet object is returned. */
   getStickerSet(args: {
@@ -967,7 +974,7 @@ export interface Telegram {
     reply_to_message_id?: Integer;
     /** A JSON-serialized object for an inline keyboard. If empty, one 'Pay total price' button will be shown. If not empty, the first button must be a Pay button. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message;
+  }): Message.InvoiceMessage;
 
   /** If you sent an invoice requesting a shipping address and the parameter is_flexible was specified, the Bot API will send an Update with a shipping_query field to the bot. Use this method to reply to shipping queries. On success, True is returned. */
   answerShippingQuery(args: {
@@ -1013,7 +1020,7 @@ export interface Telegram {
     reply_to_message_id?: Integer;
     /** A JSON-serialized object for an inline keyboard. If empty, one 'Play game_title' button will be shown. If not empty, the first button must launch the game. */
     reply_markup?: InlineKeyboardMarkup;
-  }): Message;
+  }): Message.GameMessage;
 
   /** Use this method to set the score of the specified user in a game. On success, if the message was sent by the bot, returns the edited Message, otherwise returns True. Returns an error, if the new score is not greater than the user's current score in the chat and force is False. */
   setGameScore(args: {
@@ -1031,7 +1038,7 @@ export interface Telegram {
     message_id: Integer;
     /** Required if chat_id and message_id are not specified. Identifier of the inline message */
     inline_message_id: String;
-  }): Message | True;
+  }): (Edited & Message.GameMessage) | True;
 
   /** Use this method to get data for high score tables. Will return the score of the specified user and several of their neighbors in a game. On success, returns an Array of GameHighScore objects.
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -19,6 +19,7 @@ export namespace Update {
   }
   /** Internal type holding properties that updates about edited messages share. */
   interface Edited {
+    /** Date the message was last edited in Unix time */
     edit_date: Integer;
     forward_from?: never;
     forward_from_chat?: never;

--- a/types.d.ts
+++ b/types.d.ts
@@ -833,11 +833,11 @@ export namespace KeyboardButton {
   }
   export interface RequestContactButton extends CommonButton {
     /** If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only */
-    request_contact: True;
+    request_contact: Boolean;
   }
   export interface RequestLocationButton extends CommonButton {
     /** If True, the user's current location will be sent when the button is pressed. Available in private chats only */
-    request_location: True;
+    request_location: Boolean;
   }
   export interface RequestPollButton extends CommonButton {
     /** If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only */
@@ -915,7 +915,7 @@ export namespace InlineKeyboardButton {
     /** Specify True, to send a Pay button.
 
     NOTE: This type of button must always be the first button in the first row. */
-    pay: True;
+    pay: Boolean;
   }
 }
 

--- a/types.d.ts
+++ b/types.d.ts
@@ -944,25 +944,34 @@ export interface LoginUrl {
   request_write_access?: Boolean;
 }
 
+export namespace CallbackQuery {
+  interface AbstractCallbackQuery {
+    /** Unique identifier for this query */
+    id: String;
+    /** Sender */
+    from: User;
+    /** Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old */
+    message?: Message;
+    /** Identifier of the message sent via the bot in inline mode, that originated the query. */
+    inline_message_id?: String;
+    /** Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games. */
+    chat_instance: String;
+  }
+  export interface DataCallbackQuery extends AbstractCallbackQuery {
+    /** Data associated with the callback button. Be aware that a bad client can send arbitrary data in this field. */
+    data: String;
+  }
+  export interface GameShortGameCallbackQuery extends AbstractCallbackQuery {
+    /** Short name of a Game to be returned, serves as the unique identifier for the game */
+    game_short_name: String;
+  }
+}
 /** This object represents an incoming callback query from a callback button in an inline keyboard. If the button that originated the query was attached to a message sent by the bot, the field message will be present. If the button was attached to a message sent via the bot (in inline mode), the field inline_message_id will be present. Exactly one of the fields data or game_short_name will be present.
 
 NOTE: After the user presses a callback button, Telegram clients will display a progress bar until you call answerCallbackQuery. It is, therefore, necessary to react by calling answerCallbackQuery even if no notification to the user is needed (e.g., without specifying any of the optional parameters). */
-export interface CallbackQuery {
-  /** Unique identifier for this query */
-  id: String;
-  /** Sender */
-  from: User;
-  /** Message with the callback button that originated the query. Note that message content and message date will not be available if the message is too old */
-  message?: Message;
-  /** Identifier of the message sent via the bot in inline mode, that originated the query. */
-  inline_message_id?: String;
-  /** Global identifier, uniquely corresponding to the chat to which the message with the callback button was sent. Useful for high scores in games. */
-  chat_instance: String;
-  /** Data associated with the callback button. Be aware that a bad client can send arbitrary data in this field. */
-  data?: String;
-  /** Short name of a Game to be returned, serves as the unique identifier for the game */
-  game_short_name?: String;
-}
+export type CallbackQuery =
+  | CallbackQuery.DataCallbackQuery
+  | CallbackQuery.GameShortGameCallbackQuery;
 
 /** Upon receiving a message with this object, Telegram clients will display a reply interface to the user (act as if the user has selected the bot's message and tapped 'Reply'). This can be extremely useful if you want to create user-friendly step-by-step interfaces without having to sacrifice privacy mode.
 
@@ -1414,7 +1423,6 @@ export interface InlineQueryResultMpeg4Gif {
   /** Video duration */
   mpeg4_duration?: Integer;
   /** URL of the static (JPEG or GIF) or animated (MPEG4) thumbnail for the result */
-
   thumb_url: String;
   /** MIME type of the thumbnail, must be one of “image/jpeg”, “image/gif”, or “video/mp4”. Defaults to “image/jpeg” */
   thumb_mime_type?: "image/jpeg" | "image/gif" | "video/mp4";

--- a/types.d.ts
+++ b/types.d.ts
@@ -823,17 +823,32 @@ export interface ReplyKeyboardMarkup {
   selective?: Boolean;
 }
 
-/** This object represents one button of the reply keyboard. For simple text buttons String can be used instead of this object to specify text of the button. Optional fields request_contact, request_location, and request_poll are mutually exclusive. */
-export interface KeyboardButton {
-  /** Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed */
-  text: String;
-  /** If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only */
-  request_contact?: Boolean;
-  /** If True, the user's current location will be sent when the button is pressed. Available in private chats only */
-  request_location?: Boolean;
-  /** If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only */
-  request_poll?: KeyboardButtonPollType;
+export namespace KeyboardButton {
+  export interface CommonButton {
+    /** Text of the button. If none of the optional fields are used, it will be sent as a message when the button is pressed */
+    text: String;
+  }
+  export interface RequestContactButton extends CommonButton {
+    /** If True, the user's phone number will be sent as a contact when the button is pressed. Available in private chats only */
+    request_contact: True;
+  }
+  export interface RequestLocationButton extends CommonButton {
+    /** If True, the user's current location will be sent when the button is pressed. Available in private chats only */
+    request_location: True;
+  }
+  export interface RequestPollButton extends CommonButton {
+    /** If specified, the user will be asked to create a poll and send it to the bot when the button is pressed. Available in private chats only */
+    request_poll: KeyboardButtonPollType;
+  }
 }
+
+/** This object represents one button of the reply keyboard. For simple text buttons String can be used instead of this object to specify text of the button. Optional fields request_contact, request_location, and request_poll are mutually exclusive. */
+export type KeyboardButton =
+  | KeyboardButton.CommonButton
+  | KeyboardButton.RequestContactButton
+  | KeyboardButton.RequestLocationButton
+  | KeyboardButton.RequestPollButton
+  | string;
 
 /** This object represents type of a poll, which is allowed to be created and sent when the corresponding button is pressed. */
 export interface KeyboardButtonPollType {
@@ -857,35 +872,59 @@ export interface InlineKeyboardMarkup {
   inline_keyboard: InlineKeyboardButton[][];
 }
 
-/** This object represents one button of an inline keyboard. You must use exactly one of the optional fields. */
-export interface InlineKeyboardButton {
-  /** Label text on the button */
-  text: String;
-  /** HTTP or tg:// url to be opened when button is pressed */
-  url?: String;
-  /** An HTTP URL used to automatically authorize the user. Can be used as a replacement for the Telegram Login Widget. */
-  login_url?: LoginUrl;
-  /** Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes */
-  callback_data?: String;
-  /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. Can be empty, in which case just the bot's username will be inserted.
+export namespace InlineKeyboardButton {
+  interface AbstractInlineKeyboardButton {
+    /** Label text on the button */
+    text: String;
+  }
+  export interface UrlButton extends AbstractInlineKeyboardButton {
+    /** HTTP or tg:// url to be opened when button is pressed */
+    url: String;
+  }
+  export interface LoginButton extends AbstractInlineKeyboardButton {
+    /** An HTTP URL used to automatically authorize the user. Can be used as a replacement for the Telegram Login Widget. */
+    login_url: LoginUrl;
+  }
+  export interface CallbackButton extends AbstractInlineKeyboardButton {
+    /** Data to be sent in a callback query to the bot when button is pressed, 1-64 bytes */
+    callback_data: String;
+  }
+  export interface SwitchInlineButton extends AbstractInlineKeyboardButton {
+    /** If set, pressing the button will prompt the user to select one of their chats, open that chat and insert the bot's username and the specified inline query in the input field. Can be empty, in which case just the bot's username will be inserted.
 
-  Note: This offers an easy way for users to start using your bot in inline mode when they are currently in a private chat with it. Especially useful when combined with switch_pm… actions – in this case the user will be automatically returned to the chat they switched from, skipping the chat selection screen. */
-  switch_inline_query?: String;
+    Note: This offers an easy way for users to start using your bot in inline mode when they are currently in a private chat with it. Especially useful when combined with switch_pm… actions – in this case the user will be automatically returned to the chat they switched from, skipping the chat selection screen. */
+    switch_inline_query: String;
+  }
+  export interface SwitchInlineCurrentChatButton
+    extends AbstractInlineKeyboardButton {
+    /** If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot's username will be inserted.
 
-  /** If set, pressing the button will insert the bot's username and the specified inline query in the current chat's input field. Can be empty, in which case only the bot's username will be inserted.
+    This offers a quick way for the user to open your bot in inline mode in the same chat – good for selecting something from multiple options. */
+    switch_inline_query_current_chat: String;
+  }
+  export interface GameButton extends AbstractInlineKeyboardButton {
+    /** Description of the game that will be launched when the user presses the button.
 
-  This offers a quick way for the user to open your bot in inline mode in the same chat – good for selecting something from multiple options. */
-  switch_inline_query_current_chat?: String;
+    NOTE: This type of button must always be the first button in the first row. */
+    callback_game: CallbackGame;
+  }
+  export interface PayButton extends AbstractInlineKeyboardButton {
+    /** Specify True, to send a Pay button.
 
-  /** Description of the game that will be launched when the user presses the button.
-
-  NOTE: This type of button must always be the first button in the first row. */
-  callback_game?: CallbackGame;
-  /** Specify True, to send a Pay button.
-
-  NOTE: This type of button must always be the first button in the first row. */
-  pay?: Boolean;
+    NOTE: This type of button must always be the first button in the first row. */
+    pay: True;
+  }
 }
+
+/** This object represents one button of an inline keyboard. You must use exactly one of the optional fields. */
+export type InlineKeyboardButton =
+  | InlineKeyboardButton.CallbackButton
+  | InlineKeyboardButton.GameButton
+  | InlineKeyboardButton.LoginButton
+  | InlineKeyboardButton.PayButton
+  | InlineKeyboardButton.SwitchInlineButton
+  | InlineKeyboardButton.SwitchInlineCurrentChatButton
+  | InlineKeyboardButton.UrlButton;
 
 /** This object represents a parameter of the inline keyboard button used to automatically authorize a user. Serves as a great replacement for the Telegram Login Widget when the user is coming from Telegram. All the user needs to do is tap/click a button and confirm that they want to log in.
 Telegram apps support these buttons as of version 5.7. */

--- a/types.d.ts
+++ b/types.d.ts
@@ -279,19 +279,21 @@ export namespace Message {
     /** For text messages, special entities like usernames, URLs, bot commands, etc. that appear in the text */
     entities?: MessageEntity[];
   }
-  interface MediaMessage extends CommonMessage {
+  interface CaptionableMessage extends CommonMessage {
     /** Caption for the animation, audio, document, photo, video or voice, 0-1024 characters */
     caption?: String;
     /** For messages with a caption, special entities like usernames, URLs, bot commands, etc. that appear in the caption */
     caption_entities?: MessageEntity[];
+  }
+  interface MediaMessage extends CaptionableMessage {
     /** The unique identifier of a media message group this message belongs to */
     media_group_id?: String;
   }
-  export interface AudioMessage extends MediaMessage {
+  export interface AudioMessage extends CaptionableMessage {
     /** Message is an audio file, information about the file */
     audio: Audio;
   }
-  export interface DocumentMessage extends MediaMessage {
+  export interface DocumentMessage extends CaptionableMessage {
     /** Message is a general file, information about the file */
     document: Document;
   }
@@ -315,7 +317,7 @@ export namespace Message {
     /** Message is a video note, information about the video message */
     video_note: VideoNote;
   }
-  export interface VoiceMessage extends MediaMessage {
+  export interface VoiceMessage extends CaptionableMessage {
     /** Message is a voice message, information about the file */
     voice: Voice;
   }
@@ -381,7 +383,7 @@ export namespace Message {
   }
   export interface MigrateFromChatIdMessage extends ServiceMessage {
     /** The supergroup has been migrated from a group with the specified identifier. This number may be greater than 32 bits and some programming languages may have difficulty/silent defects in interpreting it. But it is smaller than 52 bits, so a signed 64 bit integer or double-precision float type are safe for storing this identifier. */
-    migrate_from_chat_id?: Integer;
+    migrate_from_chat_id: Integer;
   }
   export interface PinnedMessageMessage extends ServiceMessage {
     /** Specified message was pinned. Note that the Message object in this field will not contain further reply_to_message fields even if it is itself a reply. */
@@ -401,7 +403,7 @@ export namespace Message {
   }
   export interface PassportDataMessage extends ServiceMessage {
     /** Telegram Passport data */
-    passport_data?: PassportData;
+    passport_data: PassportData;
   }
 }
 


### PR DESCRIPTION
> I have one more idea how to improve `Message` (https://github.com/KnorpelSenf/typegram/pull/5#pullrequestreview-474332577)

Turning message into intersection of 3 unions turned out too difficult for me to finalize at the moment:
```ts
// pseudocode
export type Message = (Edited | Forwarded | {}) & (Channel | NonChannel) & MessageKinds;
```
This is actually wrong&mdash;`ServiceMessage`s can't be edited nor forwarded as far as I know.