### PR TITLE
Make some `Update` sub-types generic

### DIFF
--- a/types.d.ts
+++ b/types.d.ts
@@ -33,21 +33,25 @@ export namespace Update {
     /** The update's unique identifier. Update identifiers start from a certain positive number and increase sequentially. This ID becomes especially handy if you're using Webhooks, since it allows you to ignore repeated updates or to restore the correct update sequence, should they get out of order. If there are no new updates for at least a week, then identifier of the next update will be chosen randomly instead of sequentially. */
     update_id: Integer;
   }
-  export interface MessageUpdate extends AbstractMessageUpdate {
+  export interface MessageUpdate<TMessage extends Message = Message>
+    extends AbstractMessageUpdate {
     /** New incoming message of any kind — text, photo, sticker, etc. */
-    message: New & NonChannel & Message;
+    message: New & NonChannel & TMessage;
   }
-  export interface EditedMessageUpdate extends AbstractMessageUpdate {
+  export interface EditedMessageUpdate<TMessage extends Message = Message>
+    extends AbstractMessageUpdate {
     /** New version of a message that is known to the bot and was edited */
-    edited_message: Edited & NonChannel & Message;
+    edited_message: Edited & NonChannel & TMessage;
   }
-  export interface ChannelPostUpdate extends AbstractMessageUpdate {
+  export interface ChannelPostUpdate<TMessage extends Message = Message>
+    extends AbstractMessageUpdate {
     /** New incoming channel post of any kind — text, photo, sticker, etc. */
-    channel_post: New & Channel & Message;
+    channel_post: New & Channel & TMessage;
   }
-  export interface EditedChannelPostUpdate extends AbstractMessageUpdate {
+  export interface EditedChannelPostUpdate<TMessage extends Message = Message>
+    extends AbstractMessageUpdate {
     /** New version of a channel post that is known to the bot and was edited */
-    edited_channel_post: Edited & Channel & Message;
+    edited_channel_post: Edited & Channel & TMessage;
   }
   export interface InlineQueryUpdate extends AbstractMessageUpdate {
     /** New incoming inline query */


### PR DESCRIPTION
To allow types like `Context<MessageUpdate<TextMessage>>` in the future; Telegraf can't use this right now due to https://github.com/microsoft/TypeScript/issues/4742, so don't bother releasing just this on npm.