### PR TITLE
Allow custom `InputFile`s without rewriting

### DIFF
--- a/methods.d.ts
+++ b/methods.d.ts
@@ -9,7 +9,7 @@ import {
   GameHighScore,
   InlineKeyboardMarkup,
   InlineQueryResult,
-  InputFile,
+  InputFile as LegacyInputFile,
   InputMedia,
   InputMediaAudio,
   InputMediaDocument,
@@ -41,6 +41,16 @@ type Ret<M extends keyof Telegram> = ReturnType<Telegram[M]>;
 /** Promisifies a given method signature */
 type P<M extends keyof Telegram> = (...args: Params<M>) => Promise<Ret<M>>;
 
+export interface Typegram<InputFile> {
+  Telegram: _Telegram<InputFile>;
+  TelegramP: { [M in keyof _Telegram<InputFile>]: P<M> };
+  Opts: {
+    [M in keyof _Telegram<InputFile>]: M extends (args?: infer O) => unknown
+      ? O
+      : {};
+  };
+}
+
 /** Utility type providing the argument type for the given method name or `{}` if the method does not take any parameters */
 export type Opts<M extends keyof Telegram> = Params<M>[0] extends undefined
   ? {}
@@ -49,7 +59,8 @@ export type Opts<M extends keyof Telegram> = Params<M>[0] extends undefined
 export type TelegramP = { [M in keyof Telegram]: P<M> };
 
 /** Wrapper type to bundle all methods of the Telegram API */
-export interface Telegram {
+export type Telegram = _Telegram<LegacyInputFile>;
+interface _Telegram<InputFile> {
   /** Use this method to receive incoming updates using long polling (wiki). An Array of Update objects is returned.
 
   Notes

--- a/methods.d.ts
+++ b/methods.d.ts
@@ -908,7 +908,7 @@ interface _Telegram<InputFile> {
     /** Required if chat_id and message_id are not specified. Identifier of the inline message */
     inline_message_id?: String;
     /** A JSON-serialized object for a new media content of the message */
-    media: InputMedia;
+    media: InputMedia<InputFile>;
     /** A JSON-serialized object for a new inline keyboard. */
     reply_markup?: InlineKeyboardMarkup;
   }):

--- a/types.d.ts
+++ b/types.d.ts
@@ -1262,7 +1262,11 @@ export interface InputMediaDocument {
   disable_content_type_detection?: Boolean;
 }
 
-/** This object represents the contents of a file to be uploaded. Must be posted using multipart/form-data in the usual way that files are uploaded via the browser. */
+/**
+ * This object represents the contents of a file to be uploaded.
+ * Must be posted using multipart/form-data in the usual way that files are uploaded via the browser.
+ * @deprecated
+ */
 export type InputFile =
   | FileId
   | InputFileByPath
@@ -1270,20 +1274,25 @@ export type InputFile =
   | InputFileByBuffer
   | InputFileByURL;
 
+/** @deprecated */
 export type FileId = String;
 
+/** @deprecated */
 export interface InputFileByPath {
   source: String;
 }
 
+/** @deprecated */
 export interface InputFileByReadableStream {
   source: NodeJS.ReadableStream;
 }
 
+/** @deprecated */
 export interface InputFileByBuffer {
   source: Buffer;
 }
 
+/** @deprecated */
 export interface InputFileByURL {
   url: String;
   filename: String;

--- a/types.d.ts
+++ b/types.d.ts
@@ -1155,12 +1155,12 @@ export interface ResponseParameters {
 - InputMediaAudio
 - InputMediaPhoto
 - InputMediaVideo */
-export type InputMedia =
-  | InputMediaAnimation
-  | InputMediaDocument
-  | InputMediaAudio
+export type InputMedia<Thumb = InputFile | String> =
+  | InputMediaAnimation<Thumb>
+  | InputMediaDocument<Thumb>
+  | InputMediaAudio<Thumb>
   | InputMediaPhoto
-  | InputMediaVideo;
+  | InputMediaVideo<Thumb>;
 
 /** Represents a photo to be sent. */
 export interface InputMediaPhoto {
@@ -1177,13 +1177,13 @@ export interface InputMediaPhoto {
 }
 
 /** Represents a video to be sent. */
-export interface InputMediaVideo {
+export interface InputMediaVideo<Thumb = InputFile | String> {
   /** Type of the result, must be video */
   type: "video";
   /** File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files » */
   media: String;
   /** Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files » */
-  thumb?: InputFile | String;
+  thumb?: Thumb;
   /** Caption of the video to be sent, 0-1024 characters after entities parsing */
   caption?: String;
   /** Mode for parsing entities in the video caption. See formatting options for more details. */
@@ -1201,13 +1201,13 @@ export interface InputMediaVideo {
 }
 
 /** Represents an animation file (GIF or H.264/MPEG-4 AVC video without sound) to be sent. */
-export interface InputMediaAnimation {
+export interface InputMediaAnimation<Thumb = InputFile | String> {
   /** Type of the result, must be animation */
   type: "animation";
   /** File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files » */
   media: String;
   /** Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files » */
-  thumb?: InputFile | String;
+  thumb?: Thumb;
   /** Caption of the animation to be sent, 0-1024 characters after entities parsing */
   caption?: String;
   /** Mode for parsing entities in the animation caption. See formatting options for more details. */
@@ -1223,13 +1223,13 @@ export interface InputMediaAnimation {
 }
 
 /** Represents an audio file to be treated as music to be sent. */
-export interface InputMediaAudio {
+export interface InputMediaAudio<Thumb = InputFile | String> {
   /** Type of the result, must be audio */
   type: "audio";
   /** File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files » */
   media: String;
   /** Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files » */
-  thumb?: InputFile | String;
+  thumb?: Thumb;
   /** Caption of the audio to be sent, 0-1024 characters after entities parsing */
   caption?: String;
   /** Mode for parsing entities in the audio caption. See formatting options for more details. */
@@ -1245,13 +1245,13 @@ export interface InputMediaAudio {
 }
 
 /** Represents a general file to be sent. */
-export interface InputMediaDocument {
+export interface InputMediaDocument<Thumb = InputFile | String> {
   /** Type of the result, must be document */
   type: "document";
   /** File to send. Pass a file_id to send a file that exists on the Telegram servers (recommended), pass an HTTP URL for Telegram to get a file from the Internet, or pass “attach://<file_attach_name>” to upload a new one using multipart/form-data under <file_attach_name> name. More info on Sending Files » */
   media: String;
   /** Thumbnail of the file sent; can be ignored if thumbnail generation for the file is supported server-side. The thumbnail should be in JPEG format and less than 200 kB in size. A thumbnail's width and height should not exceed 320. Ignored if the file is not uploaded using multipart/form-data. Thumbnails can't be reused and can be only uploaded as a new file, so you can pass “attach://<file_attach_name>” if the thumbnail was uploaded using multipart/form-data under <file_attach_name>. More info on Sending Files » */
-  thumb?: InputFile | String;
+  thumb?: Thumb;
   /** Caption of the document to be sent, 0-1024 characters after entities parsing */
   caption?: String;
   /** Mode for parsing entities in the document caption. See formatting options for more details. */


### PR DESCRIPTION
Fixes #11 by introducing a proxy type named `Typegram`, without rewriting whole library (closes #13).