### PR TITLE
Fix star re-exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,20 @@
   "version": "3.1.9",
   "description": "Type declarations for the Telegram API",
   "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./alias": "./index.js",
+    "./api": "./index.js",
+    "./callback": "./index.js",
+    "./default": "./index.js",
+    "./inline": "./index.js",
+    "./manage": "./index.js",
+    "./message": "./index.js",
+    "./passport": "./index.js",
+    "./payment": "./index.js",
+    "./proxied": "./index.js",
+    "./update": "./index.js"
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/KnorpelSenf/typegram.git"


### PR DESCRIPTION
https://github.com/telegraf/telegraf/pull/1378#issuecomment-784208798

> I'm not too familiar with how Node handles this, but I'd expect that doing `import * as foo from 'typegram/message'` would then be the same as `import * as foo from 'typegram'`, which does not solve the problem.

It does. Import succeeds at runtime, while TypeScript ignores the mapping.