### PR TITLE
Use only `CommonMessage`s in edit updates, no `ServiceMessage`s

### DIFF
--- a/message.d.ts
+++ b/message.d.ts
@@ -195,7 +195,7 @@ export namespace Message {
 }
 
 /** Helper type that bundles all possible `Message.ServiceMessage`s. More specifically, bundles all messages that do not have a `reply_to_message` field, i.e. are not a `Message.CommonMessage`. */
-type ServiceMessageBundle =
+export type ServiceMessageBundle =
   | Message.ChannelChatCreatedMessage
   | Message.ConnectedWebsiteMessage
   | Message.DeleteChatPhotoMessage
@@ -218,7 +218,7 @@ type ServiceMessageBundle =
   | Message.VoiceChatParticipantsInvitedMessage;
 
 /** Helper type that bundles all possible `Message.CommonMessage`s. More specifically, bundles all messages that do have a `reply_to_message` field, i.e. are a `Message.CommonMessage`. */
-type CommonMessageBundle =
+export type CommonMessageBundle =
   | Message.AnimationMessage
   | Message.AudioMessage
   | Message.ContactMessage

--- a/update.d.ts
+++ b/update.d.ts
@@ -1,7 +1,7 @@
 import { CallbackQuery } from "./callback";
 import { ChosenInlineResult, InlineQuery } from "./inline";
 import { Chat, ChatMemberUpdated, User } from "./manage";
-import { Message, Poll, PollAnswer } from "./message";
+import { CommonMessageBundle, Message, Poll, PollAnswer } from "./message";
 import { PreCheckoutQuery, ShippingQuery } from "./payment";
 
 export namespace Update {
@@ -43,7 +43,7 @@ export namespace Update {
   }
   export interface EditedMessageUpdate extends AbstractUpdate {
     /** New version of a message that is known to the bot and was edited */
-    edited_message: Edited & NonChannel & Message;
+    edited_message: Edited & NonChannel & CommonMessageBundle;
   }
   export interface ChannelPostUpdate extends AbstractUpdate {
     /** New incoming channel post of any kind — text, photo, sticker, etc. */
@@ -51,7 +51,7 @@ export namespace Update {
   }
   export interface EditedChannelPostUpdate extends AbstractUpdate {
     /** New version of a channel post that is known to the bot and was edited */
-    edited_channel_post: Edited & Channel & Message;
+    edited_channel_post: Edited & Channel & CommonMessageBundle;
   }
   export interface InlineQueryUpdate extends AbstractUpdate {
     /** New incoming inline query */


### PR DESCRIPTION
I decided against dropping `interface New`, it's possible to reply to edited message.