### PR TITLE
Fix up previous Bot API 6.3 support

### DIFF
--- a/manage.d.ts
+++ b/manage.d.ts
@@ -159,7 +159,7 @@ export namespace Chat {
   export interface GroupGetChat extends GroupChat, MultiUserGetChat {}
   /** Internal type representing supergroup chats returned from `getChat`. */
   export interface SupergroupGetChat
-    extends SupergroupChat, MultiUserGetChat, LargeGetChat {
+    extends SupergroupChat, NonGroupGetChat, MultiUserGetChat, LargeGetChat {
     /** For supergroups, the minimum allowed delay between consecutive messages sent by each unpriviledged user; in seconds. Returned only in getChat. */
     slow_mode_delay?: number;
     /** For supergroups, name of group sticker set. Returned only in getChat. */
@@ -168,7 +168,8 @@ export namespace Chat {
     location?: ChatLocation;
   }
   /** Internal type representing channel chats returned from `getChat`. */
-  export interface ChannelGetChat extends ChannelChat, LargeGetChat {}
+  export interface ChannelGetChat
+    extends ChannelChat, NonGroupGetChat, LargeGetChat {}
 }
 
 /** This object represents a chat. */
@@ -341,7 +342,7 @@ export interface ChatMemberRestricted {
   /** True, if the user is allowed to pin messages */
   can_pin_messages: boolean;
   /** True, if the user is allowed to create forum topics */
-  can_manage_topics?: boolean;
+  can_manage_topics: boolean;
   /** True, if the user is allowed to send text messages, contacts, locations and venues */
   can_send_messages: boolean;
   /** True, if the user is allowed to send audios, documents, photos, videos, video notes and voice notes */
@@ -352,7 +353,7 @@ export interface ChatMemberRestricted {
   can_send_other_messages: boolean;
   /** True, if the user is allowed to add web page previews to their messages */
   can_add_web_page_previews: boolean;
-  /** Date when restrictions will be lifted for this user; unix time */
+  /** Date when restrictions will be lifted for this user; unix time. If 0, then the user is restricted forever */
   until_date: number;
 }
 

--- a/markup.d.ts
+++ b/markup.d.ts
@@ -114,7 +114,7 @@ export namespace CallbackQuery {
  NOTE: After the user presses a callback button, Telegram clients will display a progress bar until you call answerCallbackQuery. It is, therefore, necessary to react by calling answerCallbackQuery even if no notification to the user is needed (e.g., without specifying any of the optional parameters). */
 export type CallbackQuery =
   | CallbackQuery.DataQuery
-  | CallbackQuery.GameQuery
+  | CallbackQuery.GameQuery;
 
 /** This object represents a custom keyboard with reply options (see Introduction to bots for details and examples). */
 export interface ReplyKeyboardMarkup {

--- a/message.d.ts
+++ b/message.d.ts
@@ -734,22 +734,6 @@ export interface WebAppData {
   button_text: string;
 }
 
-/** This object represents a service message about a new forum topic created in the chat. */
-export interface ForumTopicCreated {
-  /** Name of the topic */
-  name: string;
-  /** Color of the topic icon in RGB format */
-  icon_color: number;
-  /** Unique identifier of the custom emoji shown as the topic icon */
-  icon_custom_emoji_id?: string;
-}
-
-/** This object represents a service message about a forum topic closed in the chat. Currently holds no information. */
-export interface ForumTopicClosed {}
-
-/** This object represents a service message about a forum topic reopened in the chat. Currently holds no information. */
-export interface ForumTopicReopened {}
-
 /** This object represents a sticker. */
 export interface Sticker {
   /** Identifier for this file, which can be used to download or reuse the file */

--- a/message.d.ts
+++ b/message.d.ts
@@ -248,10 +248,7 @@ export type ServiceMessageBundle =
   | Message.VideoChatStartedMessage
   | Message.VideoChatEndedMessage
   | Message.VideoChatParticipantsInvitedMessage
-  | Message.WebAppDataMessage
-  | Message.ForumTopicCreatedMessage
-  | Message.ForumTopicClosedMessage
-  | Message.ForumTopicReopenedMessage;
+  | Message.WebAppDataMessage;
 
 /** Helper type that bundles all possible `Message.CommonMessage`s. More specifically, bundles all messages that do have a `reply_to_message` field, i.e. are a `Message.CommonMessage`. */
 export type CommonMessageBundle =

--- a/message.d.ts
+++ b/message.d.ts
@@ -188,8 +188,20 @@ export namespace Message {
     /** Service message. A user in the chat triggered another user's proximity alert while sharing Live Location. */
     proximity_alert_triggered: ProximityAlertTriggered;
   }
-  /** Service message: video chat scheduled */
+  export interface ForumTopicCreatedMessage extends ServiceMessage {
+    /** Service message: forum topic created */
+    forum_topic_created: ForumTopicCreated;
+  }
+  export interface ForumTopicClosedMessage extends ServiceMessage {
+    /** Service message: forum topic closed */
+    forum_topic_closed: ForumTopicClosed;
+  }
+  export interface ForumTopicReopenedMessage extends ServiceMessage {
+    /** Service message: forum topic reopened */
+    forum_topic_reopened: ForumTopicReopened;
+  }
   export interface VideoChatScheduledMessage extends ServiceMessage {
+    /** Service message: video chat scheduled */
     video_chat_scheduled: VideoChatScheduled;
   }
   export interface VideoChatStartedMessage extends ServiceMessage {
@@ -207,21 +219,6 @@ export namespace Message {
   export interface WebAppDataMessage extends ServiceMessage {
     /** Service message: data sent by a Web App */
     web_app_data: WebAppData;
-  }
-
-  export interface ForumTopicCreatedMessage extends ServiceMessage {
-    /** Service message: forum topic created */
-    forum_topic_created?: ForumTopicCreated;
-  }
-
-  export interface ForumTopicClosedMessage extends ServiceMessage {
-    /** Service message: forum topic closed */
-    forum_topic_closed?: ForumTopicClosed;
-  }
-
-  export interface ForumTopicReopenedMessage extends ServiceMessage {
-    /** Service message: forum topic reopened */
-    forum_topic_reopened?: ForumTopicReopened;
   }
 }
 
@@ -241,6 +238,9 @@ export type ServiceMessageBundle =
   | Message.NewChatTitleMessage
   | Message.PassportDataMessage
   | Message.ProximityAlertTriggeredMessage
+  | Message.ForumTopicCreatedMessage
+  | Message.ForumTopicClosedMessage
+  | Message.ForumTopicReopenedMessage
   | Message.PinnedMessageMessage
   | Message.SuccessfulPaymentMessage
   | Message.SupergroupChatCreated
@@ -688,6 +688,22 @@ export interface MessageAutoDeleteTimerChanged {
   /** New auto-delete time for messages in the chat; in seconds */
   message_auto_delete_time: number;
 }
+
+/** This object represents a service message about a new forum topic created in the chat. */
+export interface ForumTopicCreated {
+  /** Name of the topic */
+  name: string;
+  /** Color of the topic icon in RGB format */
+  icon_color: number;
+  /** Unique identifier of the custom emoji shown as the topic icon */
+  icon_custom_emoji_id?: string;
+}
+
+/** This object represents a service message about a forum topic closed in the chat. Currently holds no information. */
+export interface ForumTopicClosed {}
+
+/** This object represents a service message about a forum topic reopened in the chat. Currently holds no information. */
+export interface ForumTopicReopened {}
 
 /** This object represents a service message about a video chat scheduled in the chat. */
 export interface VideoChatScheduled {

--- a/proxied.d.ts
+++ b/proxied.d.ts
@@ -938,7 +938,7 @@ export interface Typegram<F> {
     setChatTitle(args: {
       /** Unique identifier for the target chat or username of the target channel (in the format @channelusername) */
       chat_id: number | string;
-      /** New chat title, 1-255 characters */
+      /** New chat title, 1-128 characters */
       title: string;
     }): true;
 
@@ -1035,7 +1035,7 @@ export interface Typegram<F> {
       name: string;
       /** Color of the topic icon in RGB format. Currently, must be one of 0x6FB9F0, 0xFFD67E, 0xCB86DB, 0x8EEE98, 0xFF93B2, or 0xFB6F5F */
       icon_color?: number;
-      /** Unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers */
+      /** Unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers. */
       icon_custom_emoji_id?: string;
     }): ForumTopic;
 
@@ -1047,7 +1047,7 @@ export interface Typegram<F> {
       message_thread_id: number;
       /** New topic name, 1-128 characters */
       name: string;
-      /** New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers */
+      /** New unique identifier of the custom emoji shown as the topic icon. Use getForumTopicIconStickers to get all allowed custom emoji identifiers. */
       icon_custom_emoji_id: string;
     }): true;
 
@@ -1237,6 +1237,7 @@ export interface Typegram<F> {
 
     /** Use this method to delete a message, including service messages, with the following limitations:
     - A message can only be deleted if it was sent less than 48 hours ago.
+    - Service messages about a supergroup, channel, or forum topic creation can't be deleted.
     - A dice message in a private chat can only be deleted if it was sent more than 24 hours ago.
     - Bots can delete outgoing messages in private chats, groups, and supergroups.
     - Bots can delete incoming messages in private chats.

--- a/update.d.ts
+++ b/update.d.ts
@@ -67,7 +67,8 @@ export namespace Update {
     /** The result of an inline query that was chosen by a user and sent to their chat partner. Please see our documentation on the feedback collecting for details on how to enable these updates for your bot. */
     chosen_inline_result: ChosenInlineResult;
   }
-  export interface CallbackQueryUpdate<C extends CallbackQuery = CallbackQuery> extends AbstractUpdate {
+  export interface CallbackQueryUpdate<C extends CallbackQuery = CallbackQuery>
+    extends AbstractUpdate {
     /** New incoming callback query */
     callback_query: C;
   }


### PR DESCRIPTION
Follow-up for #39. Lots of changes to docs strings were missing. The order of members did not correspond with the order of members in the specification. There were also some bugs and typos in which are fixed here.

This PQ also fixes some formatting problems.